### PR TITLE
PXY-fix wrong credentials for docker login

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,13 +25,14 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2.0.0
         with:
-          registry: docker.io
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v2.0.0
         with:
+          registry: docker.io
           username: ${{ secrets.CONDUKTORBOT_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.CONDUKTORBOT_DOCKER_HUB_PAT }}
 


### PR DESCRIPTION
What does this pr do? 
Seems we have wrong credential for docker login. So, swap them to make it right.