### PR TITLE
Realign version after release (0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ mvn clean package                # build the .jar, requires Java 17+
 ### Start Conduktor Gateway:
 
 ```bash
-$ export CLASSPATH=logger-interceptor/target/logger-interceptor-0.2.0-SNAPSHOT.jar # Add the logger interceptor to the classpath, or add your own interceptor jar files here
+$ export CLASSPATH=logger-interceptor/target/logger-interceptor-0.4.0-SNAPSHOT.jar # Add the logger interceptor to the classpath, or add your own interceptor jar files here
 $ bin/run-gateway.sh
 ```
 

--- a/bin/run-gateway.sh
+++ b/bin/run-gateway.sh
@@ -23,7 +23,7 @@ if [ -z "$CONFIGURATION_FILE_PATH" ]; then
   export CONFIGURATION_FILE_PATH=gateway-core/config/application.yaml
 fi
 
-export CLASSPATH=${CLASSPATH}:gateway-core/target/gateway-core-0.2.0-SNAPSHOT.jar
+export CLASSPATH=${CLASSPATH}:gateway-core/target/gateway-core-0.4.0-SNAPSHOT.jar
 
 # Run command:
 java io.conduktor.gateway.Bootstrap
@@ -31,6 +31,6 @@ java io.conduktor.gateway.Bootstrap
 # Error handling:
 retVal=$?
 if [ $retVal -ne 0 ]; then
-    echo "Gateway failed to start.  Ensure your CLASSPATH includes gateway-core-0.2.0-SNAPSHOT.jar and any interceptors defined under the pluginClass in your application.yaml" ${CLASSPATH}
+    echo "Gateway failed to start.  Ensure your CLASSPATH includes gateway-core-0.4.0-SNAPSHOT.jar and any interceptors defined under the pluginClass in your application.yaml" ${CLASSPATH}
 fi
 exit $retVal

--- a/gateway-core/pom.xml
+++ b/gateway-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.conduktor</groupId>
         <artifactId>conduktor-gateway</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.conduktor</groupId>
         <artifactId>conduktor-gateway</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.conduktor</groupId>
             <artifactId>gateway-core</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
 
 

--- a/interceptor-framework/pom.xml
+++ b/interceptor-framework/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>conduktor-gateway</artifactId>
         <groupId>io.conduktor</groupId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/logger-interceptor/pom.xml
+++ b/logger-interceptor/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.conduktor</groupId>
     <artifactId>logger-interceptor</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.conduktor</groupId>
             <artifactId>interceptor-framework</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.4.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.conduktor</groupId>
     <artifactId>conduktor-gateway</artifactId>
     <packaging>pom</packaging>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <modules>
         <module>gateway-core</module>
         <module>gateway-test</module>


### PR DESCRIPTION
## What does this PR do ?

Automation issues on protected branch leads to release of 0.2.0 and 0.3.0 from a branch [release/0.2.0](tree/release/0.2.0)
All the issues on the automation should be fixed but in the meantime we need to aliogn our main branhc to the current real development version : `0.4.0-SNAPHSOT`