### PR TITLE
PXY-600 remove docker pre-req on mvn package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,7 @@ jobs:
         run: mvn -B package deploy --file pom.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run integration tests
+        run : mvn verify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gateway-core/pom.xml
+++ b/gateway-core/pom.xml
@@ -303,7 +303,7 @@
                 <executions>
                     <execution>
                         <id>dockerBuild</id>
-                        <phase>package</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>dockerBuild</goal>
                         </goals>

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -130,7 +130,28 @@
                         <version>5.9.2</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <excludedGroups>IntegrationTest</excludedGroups>
+                </configuration>
             </plugin>
+            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>3.1.0</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test</include>
+                    </includes>
+                </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>integration-test</goal>
+                        <goal>verify</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/concurrency/GatewayConcurrencyTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/concurrency/GatewayConcurrencyTest.java
@@ -16,12 +16,15 @@
 package io.conduktor.gateway.integration.concurrency;
 
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
+import io.conduktor.gateway.integration.DockerComposeIntegrationTest;
 import io.conduktor.gateway.integration.util.ClientFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -41,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
 
     @Test
+    @Tag("IntegrationTest")
     public void multiAdmin() throws Exception {
         var pairOfClientTopic = generateTopics();
         var clientTopic1 = pairOfClientTopic.getLeft();
@@ -75,6 +79,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void multiProducers() throws Exception {
         var pairOfClientTopic = generateTopics();
         var clientTopic1 = pairOfClientTopic.getLeft();
@@ -107,6 +112,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testMultipleProducerAndSameGatewayTopic() throws ExecutionException, InterruptedException, TimeoutException {
         var executorService = Executors.newFixedThreadPool(2);
         var clientTopic = generateTopics().getLeft();
@@ -119,6 +125,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testMultipleProducerAndMultipleGatewayTopic() throws ExecutionException, InterruptedException, TimeoutException {
         var executorService = Executors.newFixedThreadPool(2);
         var pairOfClientTopic = generateTopics();
@@ -133,6 +140,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testMultipleConsumerAndSameGatewayTopic() throws ExecutionException, InterruptedException, TimeoutException {
         var pairOfClientTopic = generateTopics();
         var clientTopic1 = pairOfClientTopic.getLeft();
@@ -151,6 +159,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testMultipleConsumerAndMultipleGatewayTopic() throws ExecutionException, InterruptedException, TimeoutException {
         var pairOfClientTopic = generateTopics();
         var clientTopic1 = pairOfClientTopic.getLeft();
@@ -175,6 +184,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testFetchMultiBatchShouldReturnControlBatches() throws ExecutionException, InterruptedException {
         //create client topic 1 +  client topic 2
         var pairOfClientTopic = generateTopics();
@@ -200,6 +210,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testMultipleProducerAndConsumerWithSameGatewayTopic() throws ExecutionException, InterruptedException, TimeoutException {
         var pairOfClientTopic = generateTopics();
         var clientTopic1 = pairOfClientTopic.getLeft();
@@ -224,6 +235,7 @@ public class GatewayConcurrencyTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testMultipleProducerAndConsumerWithMultipleGatewayTopic() throws ExecutionException, InterruptedException, TimeoutException {
         var pairOfClientTopic = generateTopics();
         var clientTopic1 = pairOfClientTopic.getLeft();

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/core/GatewayMultipleBootstrapServersTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/core/GatewayMultipleBootstrapServersTest.java
@@ -22,6 +22,7 @@ import io.conduktor.gateway.integration.util.ClientFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -44,6 +45,7 @@ public class GatewayMultipleBootstrapServersTest extends BaseGatewayIntegrationT
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testMultipleBootstrapServers() throws ExecutionException, InterruptedException {
         var clientTopic = createTopic(clientFactory.kafkaAdmin(), 1, (short) 1);
         AwaitAssertUtils.awaitUntilAsserted(20, () -> {

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/core/GatewayPortRoutingTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/core/GatewayPortRoutingTest.java
@@ -19,6 +19,7 @@ import io.conduktor.gateway.config.GatewayConfiguration;
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
 import io.conduktor.gateway.integration.util.ProduceConsumeUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -28,6 +29,7 @@ public class GatewayPortRoutingTest extends BaseGatewayIntegrationTest {
     public static final int MAX_KEY = 10;
 
     @Test
+    @Tag("IntegrationTest")
     public void testProduceAndConsume() throws ExecutionException, InterruptedException {
         var clientTopic = createTopic(clientFactory.kafkaAdmin(), 1, (short) 1);
         ProduceConsumeUtils.produceAndVerify(clientFactory.gatewayProducer(), clientTopic, MAX_KEY);

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/core/GatewayTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/core/GatewayTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.common.config.ConfigResource;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -36,6 +37,7 @@ public class GatewayTest extends BaseGatewayIntegrationTest {
 
 
     @Test
+    @Tag("IntegrationTest")
     public void testCanProduceThroughGateway() throws ExecutionException, InterruptedException {
 
         var clientTopic = createTopic(clientFactory.kafkaAdmin(), 1, (short) 1);
@@ -46,6 +48,7 @@ public class GatewayTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testDescribeNonTopicConfigsNoOp() throws ExecutionException, InterruptedException {
         // this is internal playground functionality and so not subject to early version support
         // this should be disabled for early brokers
@@ -62,6 +65,7 @@ public class GatewayTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testAlterNonTopicConfigsNoOp() throws ExecutionException, InterruptedException {
         // this is internal playground functionality and so not subject to early version support
         // this should be disabled for early brokers
@@ -84,6 +88,7 @@ public class GatewayTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testAlterNonTopicConfigsIncrementalNoOp() throws ExecutionException, InterruptedException {
         // this is internal playground functionality and so not subject to early version support
         // this should be disabled for early brokers

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/error/handler/GatewayAdminErrorHandlerTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/error/handler/GatewayAdminErrorHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -36,6 +37,7 @@ public class GatewayAdminErrorHandlerTest extends BaseErrorHandlerTest {
 
     @ParameterizedTest
     @EnumSource(ExceptionMockType.class)
+    @Tag("IntegrationTest")
     public void testCreateTopics(ExceptionMockType type) throws ExecutionException, InterruptedException {
         mockException(type, ApiKeys.CREATE_TOPICS);
         createTopic(clientFactory.kafkaAdmin(), 1, (short) 1);
@@ -49,6 +51,7 @@ public class GatewayAdminErrorHandlerTest extends BaseErrorHandlerTest {
 
     @ParameterizedTest
     @EnumSource(ExceptionMockType.class)
+    @Tag("IntegrationTest")
     public void testAlterConfigs(ExceptionMockType type) throws ExecutionException, InterruptedException {
         mockException(type, ApiKeys.ALTER_CONFIGS);
         var gatewayTopic = generateClientTopic();
@@ -65,6 +68,7 @@ public class GatewayAdminErrorHandlerTest extends BaseErrorHandlerTest {
 
     @ParameterizedTest
     @EnumSource(ExceptionMockType.class)
+    @Tag("IntegrationTest")
     public void testIncrementalAlterConfigs(ExceptionMockType type) throws ExecutionException, InterruptedException {
         mockException(type, ApiKeys.INCREMENTAL_ALTER_CONFIGS);
         var gatewayTopic = generateClientTopic();
@@ -81,6 +85,7 @@ public class GatewayAdminErrorHandlerTest extends BaseErrorHandlerTest {
 
     @ParameterizedTest
     @EnumSource(ExceptionMockType.class)
+    @Tag("IntegrationTest")
     public void testDeleteTopics(ExceptionMockType type) throws ExecutionException, InterruptedException {
         mockException(type, ApiKeys.DELETE_TOPICS);
         var gatewayTopic = generateClientTopic();
@@ -93,6 +98,7 @@ public class GatewayAdminErrorHandlerTest extends BaseErrorHandlerTest {
 
     @ParameterizedTest
     @EnumSource(ExceptionMockType.class)
+    @Tag("IntegrationTest")
     public void testDescribeConfigs(ExceptionMockType type) throws ExecutionException, InterruptedException {
         mockException(type, ApiKeys.DESCRIBE_CONFIGS);
         var gatewayTopic = generateClientTopic();

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/error/handler/GatewayConsumerErrorHandlerTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/error/handler/GatewayConsumerErrorHandlerTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,6 +54,7 @@ public class GatewayConsumerErrorHandlerTest extends BaseErrorHandlerTest {
      */
     @ParameterizedTest
     @MethodSource("consumerTestArguments")
+    @Tag("IntegrationTest")
     public void testConsume(ApiKeys apiKeys, ExceptionMockType type, Class<?> expectedException) throws Exception {
         var gatewayTopic = generateClientTopic();
         try (var gatewayProducer = clientFactory.gatewayProducer()) {

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/error/handler/GatewayProducerErrorHandlerTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/error/handler/GatewayProducerErrorHandlerTest.java
@@ -19,6 +19,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,6 +45,7 @@ public class GatewayProducerErrorHandlerTest extends BaseErrorHandlerTest {
 
     @ParameterizedTest
     @MethodSource("producerTestArguments")
+    @Tag("IntegrationTest")
     public void testProduce(ApiKeys apiKeys, ExceptionMockType type, Class<?> expectedException) throws ExecutionException, InterruptedException {
         mockException(type, apiKeys);
         var gatewayTopic = generateClientTopic();

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/interceptor/LoggerInterceptorPluginIntegrationTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/interceptor/LoggerInterceptorPluginIntegrationTest.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -82,6 +83,7 @@ public class LoggerInterceptorPluginIntegrationTest extends BaseGatewayIntegrati
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testLoadsInterceptors() {
         assertThat(getInterceptorPoolService().getAllInterceptors(FetchRequest.class).size())
                 .isEqualTo(2);
@@ -92,6 +94,7 @@ public class LoggerInterceptorPluginIntegrationTest extends BaseGatewayIntegrati
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testInterceptsProduceMessages() throws ExecutionException, InterruptedException {
 
         var clientTopic = createTopic(clientFactory.kafkaAdmin(), 1, (short) 1);
@@ -114,6 +117,7 @@ public class LoggerInterceptorPluginIntegrationTest extends BaseGatewayIntegrati
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testInterceptsFetchMessages() throws ExecutionException, InterruptedException {
 
         var clientTopic = createTopic(clientFactory.kafkaAdmin(), 1, (short) 1);

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/ClassLoaderMetricsTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/ClassLoaderMetricsTest.java
@@ -16,6 +16,7 @@
 package io.conduktor.gateway.integration.metrics;
 
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ClassLoaderMetricsTest extends BaseGatewayIntegrationTest {
 
     @Test
+    @Tag("IntegrationTest")
     void classLoadingMetrics() {
         assertThat(getMetricsRegistryProvider().registry()
                 .get("jvm.classes.loaded").gauge().value()).isPositive();

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/JvmGcMetricsTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/JvmGcMetricsTest.java
@@ -16,6 +16,7 @@
 package io.conduktor.gateway.integration.metrics;
 
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -27,6 +28,7 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JvmGcMetricsTest extends BaseGatewayIntegrationTest {
     @Test
+    @Tag("IntegrationTest")
     void gcMetricsAvailableAfterGc() {
         var registry = getMetricsRegistryProvider().registry();
         System.gc();

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/JvmMemoryMetricsTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/JvmMemoryMetricsTest.java
@@ -18,6 +18,7 @@ package io.conduktor.gateway.integration.metrics;
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JvmMemoryMetricsTest extends BaseGatewayIntegrationTest {
 
     @Test
+    @Tag("IntegrationTest")
     void memoryMetrics() {
         var registry = getMetricsRegistryProvider().registry();
 

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/JvmThreadMetricsTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/JvmThreadMetricsTest.java
@@ -17,6 +17,7 @@ package io.conduktor.gateway.integration.metrics;
 
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JvmThreadMetricsTest extends BaseGatewayIntegrationTest {
     @Test
+    @Tag("IntegrationTest")
     void threadMetrics() {
         var registry = getMetricsRegistryProvider().registry();
         new JvmThreadMetrics().bindTo(registry);

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/ProcessorMetricsTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/metrics/ProcessorMetricsTest.java
@@ -18,6 +18,7 @@ package io.conduktor.gateway.integration.metrics;
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +33,7 @@ public class ProcessorMetricsTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     void cpuMetrics() {
         assertThat(registry.get("system.cpu.count").gauge().value()).isPositive();
         if (System.getProperty("os.name").toLowerCase().contains("win")) {
@@ -42,6 +44,7 @@ public class ProcessorMetricsTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     void hotspotCpuMetrics() {
 
         assertThat(registry.get("system.cpu.usage").gauge().value()).isNotNegative();

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/rebuilders/DescribeClusterRebuilderTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/rebuilders/DescribeClusterRebuilderTest.java
@@ -18,6 +18,7 @@ package io.conduktor.gateway.integration.rebuilders;
 import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.Node;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
@@ -30,6 +31,7 @@ public class DescribeClusterRebuilderTest extends BaseGatewayIntegrationTest {
 
 
     @Test
+    @Tag("IntegrationTest")
     public void testShouldReturnGatewayHostNames() throws ExecutionException, InterruptedException {
         try (var admin = clientFactory.gatewayAdmin()) {
             var brokers = admin.describeCluster().nodes().get();

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/tls/GatewaySslTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/tls/GatewaySslTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -59,6 +60,7 @@ public class GatewaySslTest extends BaseGatewayIntegrationTest {
     }
 
     @Test
+    @Tag("IntegrationTest")
     public void testConnectionOnSSlOnlyGateway() throws ExecutionException, InterruptedException {
         var client = clientFactory.gatewayAdmin();
         var topic = createTopic(client, 1, (short) 1);

--- a/gateway-test/src/test/java/io/conduktor/gateway/integration/tls/GatewayTLSTest.java
+++ b/gateway-test/src/test/java/io/conduktor/gateway/integration/tls/GatewayTLSTest.java
@@ -21,6 +21,7 @@ import io.conduktor.gateway.integration.BaseGatewayIntegrationTest;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 
@@ -42,6 +43,7 @@ public class GatewayTLSTest extends BaseGatewayIntegrationTest {
 
 
     @Test
+    @Tag("IntegrationTest")
     void testReloadCertificates() throws Exception {
         //keystore:   test/config/old/kafka-gateway.keystore.jks
         //truststore: test/config/old/kafka-gateway.truststore.jks


### PR DESCRIPTION
Our user docs say run mvn package - this called the integration tests too, which depend on docker.  Too many people don't have docker running on their system, so we should remove this dependency to get rid of one more snag around ease of running.


To do this I have:

Added in failsafe plugin to manage integration tests separately.

Excluded tests marked integration test from surefire.

Only build the docker image in the deploy stage.

Add mvn verify to gitops build, so the integration tests are still run there.